### PR TITLE
카카오 검색 화면 리팩토링

### DIFF
--- a/compose-app/src/main/java/com/hegunhee/compose/app/BottomNavItem.kt
+++ b/compose-app/src/main/java/com/hegunhee/compose/app/BottomNavItem.kt
@@ -3,14 +3,17 @@ package com.hegunhee.compose.app
 import com.hegunhee.compose.search.SearchNavGraph
 import com.hegunhee.compose.streamer.StreamerNavGraph
 import com.hegunhee.maplefinder.searchkakao.navigation.SEARCH_KAKAO_ROUTE
+import com.hegunhee.ui_component.style.BottomSheetTitle.KakaoSearchTitle
+import com.hegunhee.ui_component.style.BottomSheetTitle.StreamerTitle
+import com.hegunhee.ui_component.style.BottomSheetTitle.TwitchSearchTitle
 
 sealed class BottomNavItem(
-    val title : Int,val icon : Int, val screenRoute : String
+    val title : String,val icon : Int, val screenRoute : String
 ) {
-    object Jururu : BottomNavItem(com.hegunhee.ui_component.R.string.kakao_search, com.hegunhee.ui_component.R.drawable.ic_star_24, SEARCH_KAKAO_ROUTE)
-    object Streamer : BottomNavItem(com.hegunhee.ui_component.R.string.streamer,com.hegunhee.ui_component.R.drawable.ic_streamer_24,StreamerNavGraph.streamerRoute)
-    object Search : BottomNavItem(com.hegunhee.ui_component.R.string.search,com.hegunhee.resource_common.R.drawable.ic_search_24,SearchNavGraph.searchRoute)
+    object KakaoSearch : BottomNavItem(KakaoSearchTitle, com.hegunhee.ui_component.R.drawable.ic_star_24, SEARCH_KAKAO_ROUTE)
+    object Streamer : BottomNavItem(StreamerTitle,com.hegunhee.ui_component.R.drawable.ic_streamer_24,StreamerNavGraph.streamerRoute)
+    object Search : BottomNavItem(TwitchSearchTitle,com.hegunhee.resource_common.R.drawable.ic_search_24,SearchNavGraph.searchRoute)
 
 }
 
-val bottomNavItems = listOf<BottomNavItem>(BottomNavItem.Jururu,BottomNavItem.Streamer,BottomNavItem.Search)
+val bottomNavItems = listOf<BottomNavItem>(BottomNavItem.KakaoSearch,BottomNavItem.Streamer,BottomNavItem.Search)

--- a/compose-app/src/main/java/com/hegunhee/compose/app/BottomNavigation.kt
+++ b/compose-app/src/main/java/com/hegunhee/compose/app/BottomNavigation.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavBackStackEntry
 
@@ -21,8 +20,8 @@ fun JururuBottomNavigation(backStackEntry : State<NavBackStackEntry?>, onBottomC
         val currentRoute = backStackEntry.value?.destination?.route
         bottomNavItems.forEachIndexed { index, item ->
             BottomNavigationItem(
-                label = { Text(text = stringResource(item.title), fontSize = 9.sp) },
-                icon =  { Icon(painter = painterResource(id = item.icon), contentDescription = stringResource(id = item.title)) },
+                label = { Text(item.title, fontSize = 9.sp) },
+                icon =  { Icon(painter = painterResource(id = item.icon), contentDescription = item.title) },
                 selectedContentColor = Color.Black,
                 unselectedContentColor = Color.Black.copy(0.4f),
                 alwaysShowLabel = true,

--- a/compose/searchKakao/src/androidTest/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoSuccessScreenTest.kt
+++ b/compose/searchKakao/src/androidTest/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoSuccessScreenTest.kt
@@ -1,0 +1,102 @@
+package com.hegunhee.maplefinder.searchkakao
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.paging.PagingData
+import com.hegunhee.domain.model.kakao.KakaoSearchData
+import com.hegunhee.ui_component.style.AccuracyText
+import com.hegunhee.ui_component.style.BottomSheetTitle.KakaoSearchTitle
+import com.hegunhee.ui_component.style.RecencyText
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+
+class SearchKakaoSuccessScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun given_whenDefaultScreen_showHeaderTestAndTypeButtons() {
+        composeTestRule.setContent {
+            SearchKakaoScreen(paddingValues = PaddingValues(0.dp),SearchKakaoUiState.Init,"",{},{})
+        }
+
+        composeTestRule
+            .onNodeWithText(KakaoSearchTitle)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(AccuracyText)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(RecencyText)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun givenPagingData_whenSuccessScreen_showKakaoSearchData() {
+        val query = "주르르"
+        val kakaoSearchDataList = createKakaoSearchDataList(query)
+        val pagingData = flowOf(PagingData.from(kakaoSearchDataList))
+        val successUiState = SearchKakaoUiState.Success(query,pagingData)
+        composeTestRule.setContent {
+            SearchKakaoScreen(PaddingValues(0.dp),successUiState,query,{},{})
+        }
+
+        for(searchData in kakaoSearchDataList) {
+            when(searchData) {
+                is KakaoSearchData.Web -> {
+                    composeTestRule
+                        .onNodeWithText(searchData.title)
+                        .assertIsDisplayed()
+                }
+                is KakaoSearchData.Video -> {
+                    composeTestRule
+                        .onNodeWithText(searchData.getVideoInfo())
+                        .assertIsDisplayed()
+                }
+                is KakaoSearchData.Image -> {
+                    composeTestRule
+                        .onNodeWithText(searchData.displaySiteName)
+                        .assertIsDisplayed()
+                }
+            }
+        }
+    }
+
+    private fun createKakaoSearchDataList(query: String): List<KakaoSearchData> {
+        return listOf(
+            KakaoSearchData.Web(
+                contents = query + "내용",
+                dateTime = "",
+                title = query + "타이틀",
+                url = "https://www.naver.com",
+            ),
+            KakaoSearchData.Image(
+                sourceType = "",
+                dateTime = "",
+                displaySiteName = "$query 사이트",
+                url = "https://www.naver.com",
+                imageUrl = "",
+                thumbNailUrl = "",
+                width = 100,
+                height = 100,
+            ),
+            KakaoSearchData.Video(
+                author = "$query 지음",
+                dateTime = "",
+                playTime = 0,
+                thumbNailUrl = "",
+                title = "",
+                url = ""
+            )
+        )
+    }
+
+}

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -37,6 +37,7 @@ import com.hegunhee.ui_component.screen.ErrorScreen
 import com.hegunhee.ui_component.screen.LoadingScreen
 import com.hegunhee.ui_component.style.AccuracyText
 import com.hegunhee.ui_component.style.RecencyText
+import com.hegunhee.ui_component.style.ShareText
 import com.hegunhee.ui_component.text.ScreenHeaderText
 import org.jsoup.Jsoup
 
@@ -227,7 +228,7 @@ private fun ShareImage(
     title : String
 ) {
     Image(painter = painterResource(id = R.drawable.ic_share_24),
-        contentDescription = "공유하기",
+        contentDescription = ShareText,
         modifier = Modifier
             .clickable {
                 onShareButtonClick(

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -46,7 +46,7 @@ fun SearchKakaoScreenRoot(
     viewModel : SearchKakaoViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val (searchQuery, onQueryChanged) = remember { mutableStateOf("") }
+    val (searchQuery, onQueryChanged) = rememberSaveable { mutableStateOf("") }
     SearchKakaoScreen(
         paddingValues,
         uiState = viewModel.uiState.value,

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -36,6 +36,8 @@ import com.hegunhee.ui_component.item.SearchBar
 import com.hegunhee.ui_component.screen.ErrorScreen
 import com.hegunhee.ui_component.screen.LoadingScreen
 import com.hegunhee.ui_component.style.AccuracyText
+import com.hegunhee.ui_component.style.BottomSheetTitle
+import com.hegunhee.ui_component.style.BottomSheetTitle.KakaoSearchTitle
 import com.hegunhee.ui_component.style.RecencyText
 import com.hegunhee.ui_component.style.ShareText
 import com.hegunhee.ui_component.text.ScreenHeaderText
@@ -63,7 +65,7 @@ fun SearchKakaoScreenRoot(
 }
 
 @Composable
-private fun SearchKakaoScreen(
+fun SearchKakaoScreen(
     paddingValues: PaddingValues,
     uiState : SearchKakaoUiState,
     searchQuery: String,
@@ -75,7 +77,7 @@ private fun SearchKakaoScreen(
             .fillMaxSize()
             .padding(paddingValues)
     ) {
-        ScreenHeaderText(text = "카카오 검색")
+        ScreenHeaderText(text = KakaoSearchTitle)
         SearchBar(
             Modifier,
             searchQuery,

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -33,6 +33,8 @@ import com.hegunhee.nowinjururu.core.navigation.deeplink.DeepLink
 import com.hegunhee.nowinjururu.core.navigation.deeplink.handleDeepLink
 import com.hegunhee.resource_common.R
 import com.hegunhee.ui_component.item.SearchBar
+import com.hegunhee.ui_component.screen.ErrorScreen
+import com.hegunhee.ui_component.screen.LoadingScreen
 import com.hegunhee.ui_component.text.ScreenHeaderText
 import org.jsoup.Jsoup
 
@@ -71,10 +73,17 @@ private fun SearchKakaoScreen(
             .padding(paddingValues)
     ) {
         ScreenHeaderText(text = "카카오 검색")
-        SearchBar(Modifier, searchQuery, onQueryChanged, { onAction(SearchKakaoUiEvent.Search(query = searchQuery))})
+        SearchBar(
+            Modifier,
+            searchQuery,
+            onQueryChanged,
+            { onAction(SearchKakaoUiEvent.Search(query = searchQuery)) })
         SearchTypeButtons(onSearchSortTypeClick = onAction)
-        when(uiState) {
-            is SearchKakaoUiState.Loading -> {}
+        when (uiState) {
+            is SearchKakaoUiState.Loading -> {
+                LoadingScreen()
+            }
+
             is SearchKakaoUiState.Success -> {
                 val pagingData = uiState.kakaoPagingData.collectAsLazyPagingItems()
                 LazyColumn(
@@ -92,7 +101,10 @@ private fun SearchKakaoScreen(
                     }
                 }
             }
-            is SearchKakaoUiState.Error -> {}
+
+            is SearchKakaoUiState.Error -> {
+                ErrorScreen(exception = uiState.exception, onRetryClick = null)
+            }
         }
     }
 }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -80,6 +80,10 @@ private fun SearchKakaoScreen(
             { onAction(SearchKakaoUiEvent.Search(query = searchQuery)) })
         SearchTypeButtons(onSearchSortTypeClick = onAction)
         when (uiState) {
+            is SearchKakaoUiState.Init -> {
+
+            }
+            
             is SearchKakaoUiState.Loading -> {
                 LoadingScreen()
             }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -47,6 +47,11 @@ fun SearchKakaoScreenRoot(
     viewModel : SearchKakaoViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
+    LaunchedEffect(key1 = viewModel.deepLink) {
+        viewModel.deepLink.collect{
+            context.handleDeepLink(it)
+        }
+    }
     val (searchQuery, onQueryChanged) = rememberSaveable { mutableStateOf("") }
     SearchKakaoScreen(
         paddingValues,
@@ -55,11 +60,6 @@ fun SearchKakaoScreenRoot(
         onAction = viewModel::onAction,
         onQueryChanged,
     )
-    LaunchedEffect(key1 = viewModel.deepLink) {
-        viewModel.deepLink.collect{
-            context.handleDeepLink(it)
-        }
-    }
 }
 
 @Composable

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -223,7 +223,16 @@ private fun ShareImage(
     Image(painter = painterResource(id = R.drawable.ic_share_24),
         contentDescription = "공유하기",
         modifier = Modifier
-            .clickable { onShareButtonClick(SearchKakaoUiEvent.ShareClick(DeepLink.Share(url, title))) }
+            .clickable {
+                onShareButtonClick(
+                    SearchKakaoUiEvent.ShareClick(
+                        DeepLink.Share(
+                            url,
+                            title
+                        )
+                    )
+                )
+            }
             .size(30.dp)
     )
 }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -35,6 +35,8 @@ import com.hegunhee.resource_common.R
 import com.hegunhee.ui_component.item.SearchBar
 import com.hegunhee.ui_component.screen.ErrorScreen
 import com.hegunhee.ui_component.screen.LoadingScreen
+import com.hegunhee.ui_component.style.AccuracyText
+import com.hegunhee.ui_component.style.RecencyText
 import com.hegunhee.ui_component.text.ScreenHeaderText
 import org.jsoup.Jsoup
 
@@ -122,10 +124,10 @@ private fun SearchTypeButtons(
             .fillMaxWidth()
     ) {
         Button(onClick = { onSearchSortTypeClick(SearchKakaoUiEvent.SearchTypeAccuracy) }) {
-            Text("기본 검색")
+            Text(AccuracyText)
         }
         Button(onClick = { onSearchSortTypeClick(SearchKakaoUiEvent.SearchTypeRecency)}) {
-            Text("최신순")
+            Text(RecencyText)
         }
     }
 }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoScreen.kt
@@ -120,7 +120,7 @@ private fun SearchTypeButtons(
         Button(onClick = { onSearchSortTypeClick(SearchKakaoUiEvent.SearchTypeAccuracy) }) {
             Text("기본 검색")
         }
-        Button(onClick = { onSearchSortTypeClick(SearchKakaoUiEvent.SearchTypeAccuracy)}) {
+        Button(onClick = { onSearchSortTypeClick(SearchKakaoUiEvent.SearchTypeRecency)}) {
             Text("최신순")
         }
     }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoUiState.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoUiState.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 sealed interface SearchKakaoUiState {
 
+    object Init : SearchKakaoUiState
+
     object Loading : SearchKakaoUiState
 
     data class Success(

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
@@ -21,22 +21,30 @@ class SearchKakaoViewModel @Inject constructor(
     private val getKakaoSearchPagingDataUseCase: GetKakaoSearchPagingDataUseCase
 ) : ViewModel() {
 
-    var uiState : MutableState<SearchKakaoUiState> = mutableStateOf(SearchKakaoUiState.Loading)
+    var uiState: MutableState<SearchKakaoUiState> = mutableStateOf(SearchKakaoUiState.Loading)
         private set
 
-    private val _deepLink : MutableSharedFlow<DeepLink> = MutableSharedFlow()
-    val deepLink : SharedFlow<DeepLink> = _deepLink.asSharedFlow()
+    private val _deepLink: MutableSharedFlow<DeepLink> = MutableSharedFlow()
+    val deepLink: SharedFlow<DeepLink> = _deepLink.asSharedFlow()
 
-    fun onAction(action : SearchKakaoUiEvent) = viewModelScope.launch {
-        when(action) {
+    fun onAction(action: SearchKakaoUiEvent) = viewModelScope.launch {
+        when (action) {
             is SearchKakaoUiEvent.Search -> {
                 search(action.query)
             }
-            SearchKakaoUiEvent.SearchTypeAccuracy -> { searchAccuracy()}
-            SearchKakaoUiEvent.SearchTypeRecency -> {searchRecency() }
+
+            SearchKakaoUiEvent.SearchTypeAccuracy -> {
+                searchAccuracy()
+            }
+
+            SearchKakaoUiEvent.SearchTypeRecency -> {
+                searchRecency()
+            }
+
             is SearchKakaoUiEvent.ShareClick -> {
                 shareClick(action.deepLink)
             }
+
             is SearchKakaoUiEvent.WebLinkClick -> {
                 webLinkClick(action.deepLink)
             }
@@ -45,15 +53,31 @@ class SearchKakaoViewModel @Inject constructor(
 
     private fun search(query: String) {
         viewModelScope.launch {
-            uiState.value = SearchKakaoUiState.Success(query, getKakaoSearchPagingDataUseCase(query,KakaoSearchSortType.Accuracy,KakaoSearchType.Default,30).cachedIn(viewModelScope))
+            uiState.value = SearchKakaoUiState.Success(
+                query,
+                getKakaoSearchPagingDataUseCase(
+                    query,
+                    KakaoSearchSortType.Accuracy,
+                    KakaoSearchType.Default,
+                    30
+                ).cachedIn(viewModelScope)
+            )
         }
     }
 
     private fun searchAccuracy() {
         viewModelScope.launch {
             val state = uiState.value
-            if(state is SearchKakaoUiState.Success) {
-                uiState.value = SearchKakaoUiState.Success(state.query,getKakaoSearchPagingDataUseCase(state.query,KakaoSearchSortType.Accuracy,KakaoSearchType.Default,30).cachedIn(viewModelScope))
+            if (state is SearchKakaoUiState.Success) {
+                uiState.value = SearchKakaoUiState.Success(
+                    state.query,
+                    getKakaoSearchPagingDataUseCase(
+                        state.query,
+                        KakaoSearchSortType.Accuracy,
+                        KakaoSearchType.Default,
+                        30
+                    ).cachedIn(viewModelScope)
+                )
             }
         }
     }
@@ -61,19 +85,27 @@ class SearchKakaoViewModel @Inject constructor(
     private fun searchRecency() {
         viewModelScope.launch {
             val state = uiState.value
-            if(state is SearchKakaoUiState.Success) {
-                uiState.value = SearchKakaoUiState.Success(state.query,getKakaoSearchPagingDataUseCase(state.query,KakaoSearchSortType.Recency,KakaoSearchType.Default,30).cachedIn(viewModelScope))
+            if (state is SearchKakaoUiState.Success) {
+                uiState.value = SearchKakaoUiState.Success(
+                    state.query,
+                    getKakaoSearchPagingDataUseCase(
+                        state.query,
+                        KakaoSearchSortType.Recency,
+                        KakaoSearchType.Default,
+                        30
+                    ).cachedIn(viewModelScope)
+                )
             }
         }
     }
 
-    private fun shareClick(deepLink : DeepLink.Share) {
+    private fun shareClick(deepLink: DeepLink.Share) {
         viewModelScope.launch {
             _deepLink.emit(deepLink)
         }
     }
 
-    private fun webLinkClick(deepLink : DeepLink.Kakao) {
+    private fun webLinkClick(deepLink: DeepLink.Kakao) {
         viewModelScope.launch {
             _deepLink.emit(deepLink)
         }

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
@@ -57,7 +57,7 @@ class SearchKakaoViewModel @Inject constructor(
                 query,
                 getKakaoSearchPagingDataUseCase(
                     query,
-                    KakaoSearchSortType.Accuracy,
+                    KakaoSearchSortType.DEFAULT,
                     KakaoSearchType.Default,
                     30
                 ).cachedIn(viewModelScope)

--- a/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
+++ b/compose/searchKakao/src/main/java/com/hegunhee/maplefinder/searchkakao/SearchKakaoViewModel.kt
@@ -21,7 +21,7 @@ class SearchKakaoViewModel @Inject constructor(
     private val getKakaoSearchPagingDataUseCase: GetKakaoSearchPagingDataUseCase
 ) : ViewModel() {
 
-    var uiState: MutableState<SearchKakaoUiState> = mutableStateOf(SearchKakaoUiState.Loading)
+    var uiState: MutableState<SearchKakaoUiState> = mutableStateOf(SearchKakaoUiState.Init)
         private set
 
     private val _deepLink: MutableSharedFlow<DeepLink> = MutableSharedFlow()

--- a/compose/ui-component/src/androidTest/java/com/hegunhee/ui_component/ErrorScreenTest.kt
+++ b/compose/ui-component/src/androidTest/java/com/hegunhee/ui_component/ErrorScreenTest.kt
@@ -1,0 +1,45 @@
+package com.hegunhee.ui_component
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.hegunhee.ui_component.screen.ErrorScreen
+import com.hegunhee.ui_component.style.ErrorMessage
+import com.hegunhee.ui_component.style.RetryMessage
+import org.junit.Rule
+import org.junit.Test
+
+class ErrorScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun given_whenErrorScreen_showErrorMessage() {
+        composeTestRule.setContent {
+            ErrorScreen(
+                exception = IllegalStateException(),
+                onRetryClick = null,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(ErrorMessage)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun givenOnRetryClickListener_whenErrorScreen_showRetryMessage() {
+        composeTestRule.setContent {
+            ErrorScreen(
+                exception = IllegalStateException(),
+                onRetryClick = { },
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(RetryMessage)
+            .assertIsDisplayed()
+    }
+}

--- a/compose/ui-component/src/androidTest/java/com/hegunhee/ui_component/LoadingScreenTest.kt
+++ b/compose/ui-component/src/androidTest/java/com/hegunhee/ui_component/LoadingScreenTest.kt
@@ -1,0 +1,28 @@
+package com.hegunhee.ui_component
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.hegunhee.ui_component.screen.LoadingScreen
+import com.hegunhee.ui_component.style.LoadingMessage
+import org.junit.Rule
+import org.junit.Test
+
+class LoadingScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun given_whenLoadingScreen_showLoadingMessage() {
+        composeTestRule.setContent {
+            LoadingScreen()
+        }
+
+        composeTestRule
+            .onNodeWithText(LoadingMessage)
+            .assertIsDisplayed()
+    }
+
+}

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/screen/ErrorScreen.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/screen/ErrorScreen.kt
@@ -1,0 +1,59 @@
+package com.hegunhee.ui_component.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.hegunhee.ui_component.style.ErrorMessage
+import com.hegunhee.ui_component.style.RetryMessage
+import com.hegunhee.ui_component.style.largeTextFontSize
+import com.hegunhee.ui_component.style.middleButtonFontSize
+
+@Composable
+fun ErrorScreen(
+    modifier: Modifier = Modifier,
+    exception: Throwable,
+    onRetryClick: (() -> Unit)?,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = ErrorMessage,
+            fontSize = largeTextFontSize,
+        )
+        if(onRetryClick != null) {
+            Button(onRetryClick) {
+                Text(
+                    RetryMessage,
+                    fontSize = middleButtonFontSize,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorScreenPreview() {
+    ErrorScreen(
+        exception = IllegalStateException(),
+        onRetryClick = null,
+    )
+}
+
+@Preview
+@Composable
+private fun RetryableErrorScreenPreview() {
+    ErrorScreen(
+        exception = IllegalStateException(),
+        onRetryClick = {}
+    )
+}

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/screen/LoadingScreen.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/screen/LoadingScreen.kt
@@ -1,0 +1,34 @@
+package com.hegunhee.ui_component.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.hegunhee.ui_component.style.LoadingMessage
+import com.hegunhee.ui_component.style.largeTextFontSize
+
+@Composable
+fun LoadingScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = LoadingMessage,
+            fontSize = largeTextFontSize,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingScreenPreview() {
+    LoadingScreen(modifier = Modifier)
+}

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/Text.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/Text.kt
@@ -1,0 +1,5 @@
+package com.hegunhee.ui_component.style
+
+const val LoadingMessage = "로딩중 입니다..."
+const val ErrorMessage = "에러가 발생했습니다."
+const val RetryMessage = "재시도"

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
@@ -6,3 +6,5 @@ const val RetryMessage = "재시도"
 
 const val AccuracyText = "연관순"
 const val RecencyText = "최신순"
+
+const val ShareText = "공유하기"

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
@@ -8,3 +8,9 @@ const val AccuracyText = "연관순"
 const val RecencyText = "최신순"
 
 const val ShareText = "공유하기"
+
+object BottomSheetTitle {
+    const val KakaoSearchTitle = "카카오 검색"
+    const val StreamerTitle = "스트리머"
+    const val TwitchSearchTitle = "스트리머 검색"
+}

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/string.kt
@@ -3,3 +3,6 @@ package com.hegunhee.ui_component.style
 const val LoadingMessage = "로딩중 입니다..."
 const val ErrorMessage = "에러가 발생했습니다."
 const val RetryMessage = "재시도"
+
+const val AccuracyText = "연관순"
+const val RecencyText = "최신순"

--- a/core/domain/src/main/java/com/hegunhee/domain/model/kakao/KakaoSearchSortType.kt
+++ b/core/domain/src/main/java/com/hegunhee/domain/model/kakao/KakaoSearchSortType.kt
@@ -15,6 +15,8 @@ sealed class KakaoSearchSortType(val name : String,val sort : String) : KakaoFil
     companion object {
         val TYPE = "정렬순"
 
+        val DEFAULT = Accuracy
+
         fun findType(name : String) : KakaoSearchSortType {
             return when(name) {
                 Recency.name -> Recency


### PR DESCRIPTION
하드코딩된 string 값을 상수로 변경, 바텀 네비게이션에 주르르로 되있던 이름 카카오 검색으로 변경

This closes #84 