### PR TITLE
 스트리머 화면 디자인 일관성

### DIFF
--- a/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
+++ b/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
@@ -239,14 +239,19 @@ fun LazyListScope.streamerItem(
                     horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.hegunhee.resource_common.R.dimen.item_between_middle)),
                     verticalAlignment = Alignment.Bottom
                 ) {
-                    Text(text = RecommendOnlineMessage, fontSize = largeTextFontSize)
+                    Text(
+                        text = RecommendOnlineMessage,
+                        fontSize = largeTextFontSize,
+                        modifier = Modifier.alignByBaseline(),
+                    )
                     Text(
                         text = TwitchShowMessage,
                         fontSize = middleTextFontSize,
+                        fontWeight = Bold,
                         color = colorResource(id = com.hegunhee.resource_common.R.color.violet),
                         modifier = Modifier.clickable {
                             streamItem.platform.toDeepLink().handleDeepLink(context)
-                        })
+                        }.alignByBaseline())
                 }
             }
             item {

--- a/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
+++ b/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,6 +49,7 @@ import com.hegunhee.ui_component.style.OnlineText
 import com.hegunhee.ui_component.style.RecommendOnlineMessage
 import com.hegunhee.ui_component.style.RequestText
 import com.hegunhee.ui_component.style.TwitchShowMessage
+import com.hegunhee.ui_component.style.countTextFontSize
 import com.hegunhee.ui_component.style.followCancelMessage
 import com.hegunhee.ui_component.style.largeTextFontSize
 import com.hegunhee.ui_component.style.middleTextFontSize
@@ -156,11 +158,26 @@ fun LazyListScope.streamerItem(
     when (streamItem) {
         is StreamItem.Online -> {
             item {
-                Text(
-                    text = OnlineText,
-                    fontSize = largeTextFontSize,
-                    modifier = Modifier.padding(horizontal = dimensionResource(com.hegunhee.resource_common.R.dimen.header_start_padding))
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensionResource(com.hegunhee.resource_common.R.dimen.header_start_padding)),
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Text(
+                        text = OnlineText,
+                        fontSize = largeTextFontSize,
+                        modifier = Modifier.alignByBaseline()
+                    )
+                    Text(
+                        text = streamItem.items.size.toString(),
+                        fontSize = countTextFontSize,
+                        color = colorResource(id = com.hegunhee.resource_common.R.color.violet),
+                        fontWeight = Bold,
+                        modifier = Modifier.padding(start = 10.dp).alignByBaseline(),
+                    )
+                }
+
             }
             items(items = streamItem.items, key = { it.streamerId }) {
                 OnlineStream(
@@ -181,11 +198,25 @@ fun LazyListScope.streamerItem(
 
         is StreamItem.Offline -> {
             item {
-                Text(
-                    text = OfflineText,
-                    fontSize = largeTextFontSize,
-                    modifier = Modifier.padding(horizontal = dimensionResource(com.hegunhee.resource_common.R.dimen.header_start_padding))
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensionResource(com.hegunhee.resource_common.R.dimen.header_start_padding)),
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Text(
+                        text = OfflineText,
+                        fontSize = largeTextFontSize,
+                        modifier = Modifier.alignByBaseline()
+                    )
+                    Text(
+                        text = streamItem.items.size.toString(),
+                        fontSize = countTextFontSize,
+                        color = colorResource(id = com.hegunhee.resource_common.R.color.violet),
+                        fontWeight = Bold,
+                        modifier = Modifier.padding(start = 10.dp).alignByBaseline(),
+                    )
+                }
             }
             items(items = streamItem.items, key = { it.streamerId }) {
                 OfflineStream(

--- a/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
+++ b/compose/streamer/src/main/java/com/hegunhee/compose/streamer/StreamerScreen.kt
@@ -87,17 +87,21 @@ fun StreamerScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(LocalPaddingValues.current)
+            .padding(LocalPaddingValues.current),
+        verticalArrangement = Arrangement.Center,
     ) {
         Row(modifier = Modifier.fillMaxWidth()) {
-            ScreenHeaderText(text = StreamerTitle)
+            ScreenHeaderText(
+                text = StreamerTitle,
+            )
             Image(
                 painter = painterResource(id = R.drawable.ic_request_24),
                 contentDescription = RequestText,
                 modifier = Modifier
                     .clickable { request() }
                     .size(50.dp)
-                    .padding(top = 10.dp))
+                    .padding(top = 20.dp)
+            )
         }
 
         when (uiState) {

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/FontSize.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/style/FontSize.kt
@@ -7,3 +7,5 @@ val largeTextFontSize = 25.sp
 val middleTextFontSize = 15.sp
 
 val middleButtonFontSize = 13.sp
+
+val countTextFontSize = 20.sp

--- a/compose/ui-component/src/main/java/com/hegunhee/ui_component/text/ScreenHeaderText.kt
+++ b/compose/ui-component/src/main/java/com/hegunhee/ui_component/text/ScreenHeaderText.kt
@@ -6,19 +6,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.isSpecified
-import androidx.compose.ui.unit.sp
 import com.hegunhee.resource_common.R
 import com.hegunhee.ui_component.style.headerTextFontSize
 
 @Composable
-fun ScreenHeaderText(text : String) {
-    Text(text = text, fontSize = headerTextFontSize, maxLines = 1,modifier = Modifier.padding(
-        start = dimensionResource(id = R.dimen.header_start_padding),
-        top = dimensionResource(id = R.dimen.header_top_padding),
-        bottom = dimensionResource(id = R.dimen.header_bottom_padding),
-        end = dimensionResource(id = R.dimen.header_end_padding)
-    ))
+fun ScreenHeaderText(
+    modifier: Modifier = Modifier,
+    text: String
+) {
+    Text(
+        text = text,
+        fontSize = headerTextFontSize,
+        maxLines = 1,
+        modifier = modifier.padding(
+            start = dimensionResource(id = R.dimen.header_start_padding),
+            top = dimensionResource(id = R.dimen.header_top_padding),
+            bottom = dimensionResource(id = R.dimen.header_bottom_padding),
+            end = dimensionResource(id = R.dimen.header_end_padding)
+        )
+    )
 }
 
 @Preview


### PR DESCRIPTION
스트리머 화면에서 온라인, 오프라인 스트리머의 수를 보이게 했고
추천 방송 채널과 트위치 앱에서 보기 텍스트의 줄을 정렬했다.
그리고 스트리머 텍스트와 데이터 재호출 버튼의 정렬을 맞췄다.

This closes #109 